### PR TITLE
Don't implement Object method's for interface(s)

### DIFF
--- a/Source/Main/NProxy.Core/Internal/Definitions/InterfaceProxyDefinition.cs
+++ b/Source/Main/NProxy.Core/Internal/Definitions/InterfaceProxyDefinition.cs
@@ -50,9 +50,6 @@ namespace NProxy.Core.Internal.Definitions
 
             // Visit declaring interface types.
             proxyDefinitionVisitor.VisitInterfaces(DeclaringInterfaces);
-
-            // Visit parent type members.
-            proxyDefinitionVisitor.VisitMembers(ParentType);
         }
 
         /// <inheritdoc/>

--- a/Source/Test/NProxy.Core.Test/Internal/Definitions/InterfaceProxyDefinitionTestFixture.cs
+++ b/Source/Test/NProxy.Core.Test/Internal/Definitions/InterfaceProxyDefinitionTestFixture.cs
@@ -56,7 +56,7 @@ namespace NProxy.Core.Test.Internal.Definitions
 
             Assert.That(proxyDefinitionVisitor.PropertyInfos.Count, Is.EqualTo(6));
 
-            Assert.That(proxyDefinitionVisitor.MethodInfos.Count, Is.EqualTo(7));
+            Assert.That(proxyDefinitionVisitor.MethodInfos.Count, Is.EqualTo(3));
         }
 
         [Test]


### PR DESCRIPTION
A proxy for interface(s) is usually used to handle
in the invocation handler the methods of the
interface(s) w/o having to handle the methods from
Object like GetHashCode()/Equals() etc